### PR TITLE
src: define builtin types

### DIFF
--- a/src/builtin/builtin.go
+++ b/src/builtin/builtin.go
@@ -1,0 +1,11 @@
+package builtin
+
+// Check that builtin types are correctly graphed.
+// This simulates the real builtin package and makes sure we
+// properly handle references to builtin defs.
+
+type int int
+
+type bool bool
+
+type string string


### PR DESCRIPTION
This adds a `builtin` package which defines 3 builtin types. The `srclib-go` tests will verify that these builtin types are properly graphed.
